### PR TITLE
Session-based auth

### DIFF
--- a/src/client/scripts/menu.ts
+++ b/src/client/scripts/menu.ts
@@ -71,8 +71,8 @@ export function setupUI() {
     });
 
     elements.submitbutton.addEventListener("click", async () => {
-        let result = await authenticateUpgradeToken(elements.password.value, false);
-        if(!result) {
+        let auth = await authenticateUpgradeToken(elements.password.value, false);
+        if(!auth) {
             elements.loading.classList.add("hidden");
             elements.content.classList.remove("hidden");
             elements.password.classList.add("angry");

--- a/src/client/scripts/menu.ts
+++ b/src/client/scripts/menu.ts
@@ -1,4 +1,4 @@
-import {config, makeAPICall} from "./networking";
+import {config, makeAPICall, authenticateUpgradeToken} from "./networking";
 import elements from "./elements";
 import timeAgo from "./util/timeago";
 import {WebLogsSuccess} from "../../shared/types/weblogs";
@@ -20,14 +20,16 @@ export function setupUI() {
     }
 
     elements.adminsubmit.addEventListener("click", async () => {
-        let firstUpdateLogsResponse = await updateLogs(0); // init
-        if(firstUpdateLogsResponse == -1) {
+        let result = await authenticateUpgradeToken(elements.adminpassword.value, true);
+        if(!result) {
             elements.adminpassword.classList.add("angry");
             setTimeout(() => {
                 elements.adminpassword.classList.remove("angry");
             }, 1000);
             return;
         }
+
+        let firstUpdateLogsResponse = await updateLogs(0); // init
 
         logsLastUpdate = firstUpdateLogsResponse;
 
@@ -39,7 +41,7 @@ export function setupUI() {
         }, 1000 * 10);
 
         elements.adminlogclear.addEventListener("click", async () => {
-            await makeAPICall<WebUploadSuccess>("/api/admin/deletelogs", elements.adminpassword.value, {timeoffset: 1000 * 60 * 60 * 24});
+            await makeAPICall<WebUploadSuccess>("/api/admin/deletelogs", true, {timeoffset: 1000 * 60 * 60 * 24});
         });
 
         getUploadedFiles();
@@ -69,15 +71,8 @@ export function setupUI() {
     });
 
     elements.submitbutton.addEventListener("click", async () => {
-        let formData = new FormData(elements.form);
-
-        let xhr = new XMLHttpRequest();
-        xhr.upload.addEventListener("loadstart", loadStart);
-        xhr.upload.addEventListener("progress", progress);
-        xhr.upload.addEventListener("load", load);
-
-        let response = await makeAPICall<WebUploadSuccess>("/api/upload", elements.password.value, formData, xhr);
-        if(!response.success) {
+        let result = await authenticateUpgradeToken(elements.password.value, false);
+        if(!result) {
             elements.loading.classList.add("hidden");
             elements.content.classList.remove("hidden");
             elements.password.classList.add("angry");
@@ -86,6 +81,16 @@ export function setupUI() {
             }, 1000);
             return;
         }
+
+        let formData = new FormData(elements.form);
+
+        let xhr = new XMLHttpRequest();
+        xhr.upload.addEventListener("loadstart", loadStart);
+        xhr.upload.addEventListener("progress", progress);
+        xhr.upload.addEventListener("load", load);
+
+        let response = await makeAPICall<WebUploadSuccess>("/api/upload", true, formData, xhr);
+        if(!response.success) return;
 
         elements.loading.classList.add("hidden");
         elements.results.classList.remove("hidden");
@@ -154,7 +159,7 @@ export function setupUI() {
 }
 
 async function getUploadedFiles() {
-    let response = await makeAPICall<WebFileSuccess>("/api/admin/files", elements.adminpassword.value);
+    let response = await makeAPICall<WebFileSuccess>("/api/admin/files", true);
     if(!response.success) throw new Error("failed to get uploaded files");
     const {files} = response;
     for(let i in files) {
@@ -181,7 +186,7 @@ async function getUploadedFiles() {
                 deleteButton.innerHTML = "";
                 deleteButton.appendChild(document.createTextNode("Confirm"));
             } else { // second click
-                await makeAPICall<WebSuccess>("/api/admin/delete", elements.adminpassword.value, {filename: file.file.filename});
+                await makeAPICall<WebSuccess>("/api/admin/delete", true, {filename: file.file.filename});
                 filediv.remove();
             }
         });
@@ -203,7 +208,7 @@ async function getUploadedFiles() {
 }
 
 async function updateLogs(lastUpdate:number):Promise<number> {
-    let response = await makeAPICall<WebLogsSuccess>("/api/admin/logs", elements.adminpassword.value, {minimumtime: lastUpdate});
+    let response = await makeAPICall<WebLogsSuccess>("/api/admin/logs", true, {minimumtime: lastUpdate});
     if(!response.success) return -1;
     const {logs} = response;
     for(let i in logs) {

--- a/src/client/scripts/networking.ts
+++ b/src/client/scripts/networking.ts
@@ -24,14 +24,15 @@ export const getConfig = new Promise<void>(async (resolve) => {
  */
 export function makeAPICall<T extends WebSuccess>(path:string, authneeded:boolean, data?:FormData | {[unit:string]:any}, customXHR?:XMLHttpRequest):Promise<WebResponse<T>> {
     return new Promise((resolve, reject) => {
-        let tokenData = getToken();
+        let tokenData;
+        if(authneeded) tokenData = getToken();
         if(!tokenData && authneeded) reject();
         let token;
         if(authneeded) token = tokenData!.token;
 
         let xhr = customXHR ? customXHR : new XMLHttpRequest();
         xhr.open("POST", path, true);
-        if(token) xhr.setRequestHeader("token", token);
+        if(authneeded) xhr.setRequestHeader("token", token);
         if(!(data instanceof FormData)) xhr.setRequestHeader("Content-Type", "application/json");
 
         xhr.addEventListener("readystatechange", (e) => {
@@ -65,6 +66,7 @@ export function getToken():GetTokenResult | undefined {
         localStorage.removeItem("token");
         localStorage.removeItem("tokenExpiry");
         localStorage.removeItem("tokenPermissions");
+        localStorage.removeItem("tokenForInstanceHash");
 
         return;
     }
@@ -74,6 +76,7 @@ export function getToken():GetTokenResult | undefined {
         localStorage.removeItem("token");
         localStorage.removeItem("tokenExpiry");
         localStorage.removeItem("tokenPermissions");
+        localStorage.removeItem("tokenForInstanceHash");
 
         return;
     }
@@ -112,12 +115,14 @@ export function authenticateUpgradeToken(password:string, admin:boolean):Promise
                 localStorage.removeItem("token");
                 localStorage.removeItem("tokenExpiry");
                 localStorage.removeItem("tokenPermissions");
+                localStorage.removeItem("tokenForInstanceHash");
                 return resolve(false);
             }
 
             localStorage.setItem("token", response.token);
             localStorage.setItem("tokenExpiry", response.expires.toString());
             localStorage.setItem("tokenPermissions", tokenResult ? (tokenResult.permissions | response.grantedPermissions).toString() : response.grantedPermissions.toString());
+            localStorage.setItem("tokenForInstanceHash", config.instanceHash);
             resolve(true);
         });
         

--- a/src/client/scripts/networking.ts
+++ b/src/client/scripts/networking.ts
@@ -1,10 +1,13 @@
 import {WebConfigSuccess} from "../../shared/types/webconfig";
 import WebResponse, {WebSuccess} from "../../shared/types/webresponse";
+import PermissionSet from "../../shared/types/permission";
+import AuthRequest from "../../shared/types/request/authrequest";
+import {WebAuthSuccess} from "../../shared/types/webauth";
 
 export let config:WebConfigSuccess;
 
 export const getConfig = new Promise<void>(async (resolve) => {
-    let response = await makeAPICall<WebConfigSuccess>("/api/config");
+    let response = await makeAPICall<WebConfigSuccess>("/api/config", false);
     if(!response.success) throw new Error("Get config fail!");
     config = response;
     resolve();
@@ -19,11 +22,16 @@ export const getConfig = new Promise<void>(async (resolve) => {
  * @param customXHR if specified api call will use this xhr object for request. Intended use is so that code that needs to hook into events like progress and loadStart can use the same generic method.
  * @returns Typed information on success, void on failure with blocking alert() call beforehand
  */
-export function makeAPICall<T extends WebSuccess>(path:string, password?:string, data?:FormData | {[unit:string]:any}, customXHR?:XMLHttpRequest):Promise<WebResponse<T>> {
+export function makeAPICall<T extends WebSuccess>(path:string, authneeded:boolean, data?:FormData | {[unit:string]:any}, customXHR?:XMLHttpRequest):Promise<WebResponse<T>> {
     return new Promise((resolve, reject) => {
+        let tokenData = getToken();
+        if(!tokenData && authneeded) reject();
+        let token;
+        if(authneeded) token = tokenData!.token;
+
         let xhr = customXHR ? customXHR : new XMLHttpRequest();
         xhr.open("POST", path, true);
-        if(password) xhr.setRequestHeader("password", password);
+        if(token) xhr.setRequestHeader("token", token);
         if(!(data instanceof FormData)) xhr.setRequestHeader("Content-Type", "application/json");
 
         xhr.addEventListener("readystatechange", (e) => {
@@ -36,5 +44,71 @@ export function makeAPICall<T extends WebSuccess>(path:string, password?:string,
         if(data && (data instanceof FormData)) xhr.send(data);
         else if(data) xhr.send(JSON.stringify(data));
         else xhr.send();
+    });
+}
+
+export interface GetTokenResult {
+    token:string,
+    permissions:PermissionSet
+}
+
+/**
+ * Get token and permissions from localstorage
+ * 
+ * @returns undefined if the token does not exist, or if the token is expired
+ */
+export function getToken():GetTokenResult | undefined {
+    let token = localStorage.getItem("token");
+    if(!token) return;
+    
+    let expiry = parseInt(localStorage.getItem("tokenExpiry")!);
+    if(expiry < Date.now()) {
+        localStorage.removeItem("token");
+        localStorage.removeItem("tokenExpiry");
+        localStorage.removeItem("tokenPermissions");
+
+        return;
+    }
+
+    let permissions = parseInt(localStorage.getItem("tokenPermissions")!);
+
+    return {
+        token,
+        permissions
+    }
+}
+
+/**
+ * Get a new token, or upgrade an existing token with more permissions
+ * 
+ * @param password if no password is required for upload, can be filled with any abritrary data
+ * @param admin if true try admin password/login, if false try upload password/login
+ */
+export function authenticateUpgradeToken(password:string, admin:boolean):Promise<boolean> {
+    return new Promise((resolve, reject) => {
+        let xhr = new XMLHttpRequest();
+        xhr.open("POST", "/api/auth/authenticate", true);
+
+        let request:AuthRequest = {
+            type: admin ? "admin" : "upload",
+            password
+        }
+        let tokenResult = getToken();
+        if(tokenResult) request.token = tokenResult.token;
+
+        xhr.addEventListener("readystatechange", () => {
+            if(xhr.readyState != 4) return;
+
+            let response = JSON.parse(xhr.responseText) as WebResponse<WebAuthSuccess>;
+            if(!response.success) return resolve(false);
+
+            localStorage.setItem("token", response.token);
+            localStorage.setItem("tokenExpiry", response.expires.toString());
+            localStorage.setItem("tokenPermissions", response.grantedPermissions.toString());
+            resolve(true);
+        });
+        
+        xhr.setRequestHeader("Content-Type", "application/json");
+        xhr.send(JSON.stringify(request));
     });
 }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -16,6 +16,9 @@ import {WebConfigSuccess} from "../shared/types/webconfig";
 import FileMetadata from "../shared/types/filemetadata";
 import {WebFile} from "../shared/types/webfiles";
 import AuthRequest from "../shared/types/request/authrequest";
+import randomString from "./util/genrandom";
+
+const instanceHash = randomString(32);
 
 database().then(db => {
     let dbc = new DbConnection(db);
@@ -24,7 +27,7 @@ database().then(db => {
     logger.log("Starting filecan...");
     logger.log("Database loaded...");
 
-    const sessions = new SessionManager(1000 * 60 * 60 * 24 * 30); // 30 days
+    const sessions = new SessionManager(1000 * 60 * 60 * 24 * 7 * 2); // 2 weeks
 
     const app = express();
     app.set("trust proxy", true);
@@ -90,7 +93,7 @@ database().then(db => {
         }
 
         let session:Session;
-        if(req.body.session && typeof(req.body.session) == "string") {
+        if(req.body.token && typeof(req.body.token) == "string") {
             session = sessions.get(req.body.token);
             if(!session) return res.json({
                 success: false,
@@ -167,7 +170,8 @@ database().then(db => {
         let webconfig:WebConfigSuccess = {
             success: true,
             requirePassword: config.requirePassword,
-            maxFilesizeMegabytes: config.maxFilesizeMegabytes
+            maxFilesizeMegabytes: config.maxFilesizeMegabytes,
+            instanceHash
         }
         if(config.customURLPath) webconfig.customURLPath = config.customURLPath;
 

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -9,6 +9,7 @@ export default function auth(req:express.Request, res:express.Response, next:exp
     let logger = new Logger(res.locals.db, "auth");
 
     if(!(req.headers.token && typeof(req.headers.token) == "string")) {
+        console.log(req.headers.token);
         logger.warn(`[auth fail] [malformed] ${getIP(req)} attempted access, malformed request`);
         return res.status(400).json({
             success: false,
@@ -25,6 +26,7 @@ export default function auth(req:express.Request, res:express.Response, next:exp
             message: "Invalid token"
         });
     }
+    session.interactionObserved();
 
     const permissions = session.permissions;
     if(admin) {

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -9,7 +9,6 @@ export default function auth(req:express.Request, res:express.Response, next:exp
     let logger = new Logger(res.locals.db, "auth");
 
     if(!(req.headers.token && typeof(req.headers.token) == "string")) {
-        console.log(req.headers.token);
         logger.warn(`[auth fail] [malformed] ${getIP(req)} attempted access, malformed request`);
         return res.status(400).json({
             success: false,

--- a/src/server/middleware/auth.ts
+++ b/src/server/middleware/auth.ts
@@ -1,40 +1,42 @@
 import * as express from "express";
-import bcrypt from "bcrypt";
+import SessionManager from "../session";
+import {hasPermission} from "../permissions";
+import Permission from "../../shared/types/permission";
 import Logger from "../log";
 import {getIP} from "../ip";
-import config from "../config";
 
-export default function auth(req:express.Request, res:express.Response, next:express.NextFunction, admin:boolean) {
+export default function auth(req:express.Request, res:express.Response, next:express.NextFunction, sessions:SessionManager, admin:boolean) {
     let logger = new Logger(res.locals.db, "auth");
 
-    if(!config.requirePassword && !admin) return next();
-    let password = req.headers.password;
-    if(!password) {
-        res.status(400).json({
-            success: false,
-            message: "Password is missing"
-        });
-        logger.warn(`[auth fail] [missing] ${getIP(req)} attempted access, password missing`);
-    } else if(typeof password === "object") {
-        res.status(400).json({
-            success: false,
-            message: "Send password once only"
-        });
+    if(!(req.headers.token && typeof(req.headers.token) == "string")) {
         logger.warn(`[auth fail] [malformed] ${getIP(req)} attempted access, malformed request`);
-    } else {
-        let adminPasswordh:string, passwordh:string;
-        adminPasswordh = config.adminPassword;
-        passwordh = config.password;
-        bcrypt.compare(password, admin ? adminPasswordh : passwordh, (err, matches) => {
-            if(err) throw err;
-            if(matches) next();
-            else {
-                res.status(401).json({
-                    success: false,
-                    message: "Incorrect password"
-                });
-                logger.warn(`[auth fail] [fail] ${getIP(req)} attempted access, incorrect password`);
-            }
+        return res.status(400).json({
+            success: false,
+            message: "Malformed request"
         });
     }
+
+    let token = req.headers.token;
+    let session = sessions.get(token);
+    if(!session) {
+        logger.warn(`[auth fail] [malformed] ${getIP(req)} attempted access, malformed request`);
+        return res.status(400).json({
+            success: false,
+            message: "Invalid token"
+        });
+    }
+
+    const permissions = session.permissions;
+    if(admin) {
+        if(hasPermission(permissions, Permission.Admin)) return next();
+    } else {
+        if(hasPermission(permissions, Permission.Upload)) return next();
+    }
+
+    // insufficient permissions
+    logger.warn(`[auth fail] [permission] ${getIP(req)} attempted access, insufficient permissions for ${admin ? "admin" : "upload"}`);
+    return res.status(400).json({
+        success: false,
+        message: "Insufficient permissions"
+    });
 }

--- a/src/server/permissions.ts
+++ b/src/server/permissions.ts
@@ -1,0 +1,7 @@
+import Permission from "../shared/types/permission";
+
+export type PermissionSet = number | Permission;
+
+export function hasPermission(set:PermissionSet, permission:Permission):boolean {
+    return (set & permission) > 0;
+}

--- a/src/server/permissions.ts
+++ b/src/server/permissions.ts
@@ -1,6 +1,4 @@
-import Permission from "../shared/types/permission";
-
-export type PermissionSet = number | Permission;
+import Permission, {PermissionSet} from "../shared/types/permission";
 
 export function hasPermission(set:PermissionSet, permission:Permission):boolean {
     return (set & permission) > 0;

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -1,0 +1,91 @@
+import randomString from "./util/genrandom";
+import SessionMetadata from "../shared/types/sessionmetadata";
+
+export class Session {
+    token:string;
+    created:Date;
+    expiry:Date;
+    lastInteraction:Date | undefined;
+
+    constructor(token:string, expiry:Date) {
+        this.token = token;
+        this.created = new Date();
+        this.expiry = expiry;
+    }
+
+    /**
+     * @returns number of milliseconds until the session expires
+     */
+    timeToExpiry():number {
+        return this.expiry.getTime() - Date.now();
+    }
+
+    /**
+     * This session has been looked up via the "api-specific" existence method, clearly it is being used
+     */
+    interactionObserved() {
+        this.lastInteraction = new Date();
+    }
+
+    /**
+     * @returns JSON-serialized public-safe metadata for session
+     */
+    serializeMetadata():SessionMetadata {
+        return {
+            created: this.created.getTime(),
+            lastInteraction: this.lastInteraction.getTime()
+        }
+    }
+}
+
+export default class SessionManager {
+    private sessions:{[unit:string]:{session:Session, timeout:NodeJS.Timeout}};
+
+    constructor() {
+        this.sessions = {};
+    }
+
+    /**
+     * Adds an expiring session to the pool.
+     * 
+     * @param lifespan Number of milliseconds the session should live for
+     * @returns Token for use with api
+     */
+    add(lifespan:number):string {
+        let token = randomString(64);
+        this.sessions[token].session = new Session(token, new Date(Date.now() + lifespan));
+        this.sessions[token].timeout = setTimeout(() => {
+            this.delete(token);
+        }, lifespan);
+
+        return token;
+    }
+    
+    delete(token:string):boolean {
+        if(!this.get(token)) return false;
+
+        clearInterval(this.sessions[token].timeout);
+        delete this.sessions[token];
+        return true;
+    }
+
+    /**
+     * Does not trigger interaction update recording, can also be used to check existence of token
+     * @returns undefined if token does not exist
+     */
+    get(token:string):Session | undefined {
+        if(!this.sessions[token]) return undefined;
+        return this.sessions[token].session;
+    }
+
+    /**
+     * Check if a provided token exists. This method is intended for use via the web middleware,
+     * so using it will update the "last interacted" parameter inside the session.
+     */
+    isValid(token:string):boolean {
+        if(!this.sessions[token]) return false;
+
+        this.sessions[token].session.interactionObserved();
+        return true;
+    }
+}

--- a/src/server/session.ts
+++ b/src/server/session.ts
@@ -60,10 +60,10 @@ export default class SessionManager {
      */
     add(permissions:PermissionSet):string {
         let token = randomString(64);
-        this.sessions[token].session = new Session(token, permissions, new Date(Date.now() + this.sessionLifespan));
-        this.sessions[token].timeout = setTimeout(() => {
-            this.revoke(token);
-        }, this.sessionLifespan);
+        this.sessions[token] = {
+            session: new Session(token, permissions, new Date(Date.now() + this.sessionLifespan)),
+            timeout: setTimeout(() => {this.revoke(token)}, this.sessionLifespan)
+        }
 
         return token;
     }

--- a/src/shared/types/permission.ts
+++ b/src/shared/types/permission.ts
@@ -1,0 +1,8 @@
+enum Permission {
+    None = 0,
+    Upload = 1,
+    Admin = 2,
+    All = Upload | Admin
+}
+
+export default Permission;

--- a/src/shared/types/permission.ts
+++ b/src/shared/types/permission.ts
@@ -4,5 +4,6 @@ enum Permission {
     Admin = 2,
     All = Upload | Admin
 }
-
 export default Permission;
+
+export type PermissionSet = number | Permission;

--- a/src/shared/types/request/authrequest.ts
+++ b/src/shared/types/request/authrequest.ts
@@ -1,0 +1,7 @@
+interface AuthRequest {
+    type: "upload" | "admin",
+    password:string,
+    token?:string
+}
+
+export default AuthRequest;

--- a/src/shared/types/sessionmetadata.ts
+++ b/src/shared/types/sessionmetadata.ts
@@ -1,0 +1,4 @@
+export default interface SessionMetadata {
+    created:number;
+    lastInteraction:number;
+}

--- a/src/shared/types/webauth.ts
+++ b/src/shared/types/webauth.ts
@@ -1,0 +1,11 @@
+import WebResponse, {WebSuccess} from "./webresponse";
+import {PermissionSet} from "./permission";
+
+export interface WebAuthSuccess extends WebSuccess {
+    token:string,
+    grantedPermissions:PermissionSet;
+    expires:number;
+}
+
+type WebAuth = WebResponse<WebAuthSuccess>;
+export default WebAuth;

--- a/src/shared/types/webconfig.ts
+++ b/src/shared/types/webconfig.ts
@@ -4,6 +4,7 @@ export interface WebConfigSuccess extends WebSuccess {
     requirePassword:boolean;
     customURLPath?:string;
     maxFilesizeMegabytes:number;
+    instanceHash:string;
 }
 
 type WebConfig = WebResponse<WebConfigSuccess>;


### PR DESCRIPTION
Switch from a system where admin or upload password is sent with every request to a token-based system where one login api call is used to get an expiring token which is then used for the api

Benefits
- Don't implicitly need the password at all times, this means that "login once" is now supported without storing the plaintext password in localstorage or whatever
- Redesign of auth means that it is now much simpler to implement user-based permissions/logins if wanted in the future (could still do with a little more fine-tuning)
- Preps for UI overhaul